### PR TITLE
Repl debugging

### DIFF
--- a/src/client_repl.py
+++ b/src/client_repl.py
@@ -3,60 +3,14 @@ import sys
 from zk_helpers import get_zookeeper_hosts
 from pubsubClient import PubSubClient
 
-# ========= REPL AST =========
-class Consume: 
-    def __init__(self, topic, index):
-        self.topic = topic
-        self.index = index
-    def __str__(self):
-        return "Consume(topic={}, index={})".format(self.topic, self.index)
-
-class Publish: 
-    def __init__(self, topic, message):
-        self.topic = topic
-        self.message = message
-    def __str__(self):
-        return "Publish(topic={}, message={})".format(self.topic, self.message)
-
-class Quit: 
-    def __init__(self):
-        pass
-    def __str__(self):
-        return "Quit()"
-
-# ========= END REPL AST =========
-
-def parse_line(line): 
-    remaining = line.strip()
-    boxed = remaining.split(" ", 1)
-    if len(boxed) == 1:
-        cmd = boxed[0]
-        remaining = ""
-    else:
-        cmd, remaining = [x.strip() for x in remaining.split(" ", 1)]
-    
-    if cmd == "publish": 
-        topic, message = remaining.strip().split(" ", 1)
-        return Publish(topic.strip(), message.strip())
-    elif cmd == "consume":
-        if " " in remaining:
-            topic, index = remaining.strip().split(" ", 1)
-            topic, index = topic.strip(), index.strip()
-            if not index.isdigit():
-                raise Exception("consume index must be a number")
-            index = int(index)
-        else:
-            topic = remaining.strip()
-            index = None
-        return Consume(topic, index)
-    elif cmd == "q":
-        return Quit()
-    else: 
-        raise Exception("parse error") 
-
+# ===== REPL ENVIRONMENT =====
 class REPLEnv: 
     def __init__(self):
+        self.target = None
         self.topics = {}
+
+    def single_node_mode(self):
+        return self.target != None
 
     def set_index(self, topic, new_index): 
         self.topics[topic] = new_index
@@ -65,13 +19,62 @@ class REPLEnv:
         if topic not in self.topics:
             return 0
         return self.topics[topic]
+
+# ===== END REPL ENVIRONMENT =====
+
+def parse_args(string):
+    remaining = string.strip()
+    quotes_indices = [pos for pos, char in enumerate(remaining) if char == '"']
+    if len(quotes_indices) % 2 != 0:
+        raise Exception("Invalid use of quotations")
+    pairs = [(quotes_indices[i]+1, quotes_indices[i+1]) for i in range(0, len(quotes_indices), 2)]
+    start = 0
+    args = []
+    for i, p in enumerate(pairs):
+        if p[0] - start > 0:
+            [args.append(x.strip()) for x in remaining[start:p[0]-1].split(" ") if x != ""]
+        args.append(remaining[p[0]:p[1]])
+        if i == len(pairs)-1 and len(remaining) - p[1] > 0:
+            [args.append(x.strip()) for x in remaining[p[1]+1:len(remaining)].split(" ") if x != ""]
+        start = p[1] + 1
+    return args
+
+# TODO Clean up the command parser, do a little more testing verify
+def parse_line(line): 
+    tokens = parse_args(line)
+    cmd = tokens[0]
+    if cmd == "publish": 
+        if len(tokens) != 3:
+            raise Exception("usage: publish <topic> <message>")
+        topic, message = tokens[1], tokens[2]
+        return Publish(topic.strip(), message.strip())
+    elif cmd == "consume":
+        if len(tokens) == 2:
+            topic, index = remaining.strip(), None
+        elif len(tokens) == 3:
+            topic, index = tokens[1], tokens[2]
+            if not index.isdigit():
+                raise Exception("usage: publish <topic> <message>")
+        else:
+            
+        return Consume(topic, index)
+    elif cmd == "brokers":
+        return Brokers()
+    elif cmd == "primary":
+        topic = remaining.strip().split(" ", 1)[0]
+        return Primary(topic.strip())
+    elif cmd == "target":
+        address = remaining.strip()
+        return Target(address) 
+    elif cmd == "q":
+        return Quit()
         
 def perform(client, env, action):
     if isinstance(action, Publish):
         if client.publish(action.topic, action.message): 
-            print("{} Succeeded.".format(action))
+            print("{} succeeded.".format(action))
         else:
-            print("{} Failed.".format(action))
+            print("{} failed.".format(action))
         return True
     if isinstance(action, Consume): 
         index = env.get_index(action.topic) if action.index is None else action.index
@@ -80,18 +83,86 @@ def perform(client, env, action):
         env.set_index(action.topic, new_index)
         print("\n".join(messages))
         return True
+    if isinstance(action, Brokers): 
+        brokers = client.fetch_brokers()
+        print("\n".join([str(x) for x in brokers]))
+        return True
+    if isinstance(action, Primary): 
+        primary = client.primary(action.topic)
+        print(primary[0])
+        return True
+    if isinstance(action, Target):
+        env.target = action.address
+        return True
     if isinstance(action, Quit): 
+        if env.single_node_mode():
+            env.target = None
+            return True
         return False
+    return True
 
 def main(zookeeper_addresses):
     env = REPLEnv()
     client = PubSubClient(zookeeper_addresses)
     while True:
-        user_input = input(" > ")
+        prompt = " ({}) > ".format(env.target) if env.single_node_mode() else " > "
+        user_input = input(prompt)
         action = parse_line(user_input)
         if not perform(client, env, action):
             return 
-    
+
+# ========= REPL AST =========
+class Consume: 
+    def __init__(self, topic, index):
+        self.topic = topic
+        self.index = index
+    def __str__(self):
+        return "Consume(topic={}, index={})".format(self.topic, self.index)
+    def __eq__(self, obj):
+        return isinstance(obj, Consume) and obj.topic == self.topic and obj.index == self.index
+
+class Publish: 
+    def __init__(self, topic, message):
+        self.topic = topic
+        self.message = message
+    def __str__(self):
+        return "Publish(topic={}, message={})".format(self.topic, self.message)
+    def __eq__(self, obj):
+        return isinstance(obj, Publish) and obj.topic == self.topic and obj.message == self.message
+
+class Target: 
+    def __init__(self, address):
+        self.address = address
+    def __str__(self):
+        return "Target({})".format(self.address)
+    def __eq__(self, obj):
+        return isinstance(obj, Target) and obj.address == self.address
+
+class Quit: 
+    def __init__(self):
+        pass
+    def __str__(self):
+        return "Quit()"
+    def __eq__(self, obj):
+        return isinstance(obj, Quit)
+
+class Brokers: 
+    def __init__(self):
+        pass
+    def __str__(self):
+        return "Brokers()"
+    def __eq__(self, obj):
+        return isinstance(obj, Brokers)
+class Primary: 
+    def __init__(self, topic):
+        self.topic = topic
+    def __str__(self):
+        return "Primary()"
+    def __eq__(self, obj):
+        return isinstance(obj, Primary) and self.topic == obj.topic
+
+# ========= END REPL AST =========
+
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: python src/client_repl.py <zk_config>") 

--- a/src/client_repl_test.py
+++ b/src/client_repl_test.py
@@ -1,0 +1,38 @@
+import unittest
+
+from client_repl import *
+
+class TestParser(unittest.TestCase):
+
+    def test_one(self):
+        self.assertEqual(parse_line("publish hi message"), Publish("hi", "message"))
+    
+    def test_two(self):
+        self.assertEqual(parse_line("consume hi"), Consume("hi", None))
+
+    def test_three(self):
+        self.assertEqual(parse_line("consume hi 3"), Consume("hi", 3))
+    
+    def test_four(self):
+        self.assertEqual(parse_line("q"), Quit())
+        
+    def test_five(self):
+        self.assertEqual(parse_line("primary test_key"), Primary("test_key"))
+
+    def test_six(self):
+        self.assertEqual(parse_line("brokers test_key"), Brokers())
+
+    def test_seven(self):
+        self.assertEqual(parse_line("target localhost:3001"), Target("localhost:3001"))
+
+    def test_8(self):
+        self.assertEqual(parse_args("\"first one\" \"second one\""), ["first one", "second one"])
+    
+    def test_9(self):
+        self.assertEqual(parse_args("first one \"second one\""), ["first", "one", "second one"])
+
+    def test_10(self):
+        self.assertEqual(parse_args("first \"one second\" one"), ["first", "one second", "one"])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/pubsubClient.py
+++ b/src/pubsubClient.py
@@ -66,6 +66,13 @@ class PubSubClient:
         broker_rpc = buildBrokerClient(broker[0].key)
         return broker_rpc.broker.consume(topic, index)
 
+    def primary(self, topic):
+        broker = find_chord_successor(topic, self.brokers)
+        return broker
+
+    def fetch_brokers(self):
+        return self.brokers
+
     #==============================
     # Private Methods
 

--- a/src/topic.py
+++ b/src/topic.py
@@ -1,71 +1,16 @@
 import threading 
 
-def indexed_enqueue(topic, ooo_buffer, message, index):
+def consuming_enqueue(topic, client, message, index):
     next_expected = topic.next_index()
-    if ooo_buffer.has(next_expected, index):
-        [topic.publish(m) for m in ooo_buffer.extract(next_expected, index)]
-    if index == topic.next_index(): 
+    if index < next_expected:
+        return
+    elif index > next_expected:
+        messages = client.broker.consume(topic, next_expected)
+        for m in messages:
+            topic.publish(m)
+    else:
         topic.publish(message)
-    elif index > topic.next_index():            
-        ooo_buffer.publish(message, index)
-    latest_known_message = ooo_buffer.max()
-    if latest_known_message[1] < 0:
-        return 
-    if ooo_buffer.has(topic.next_index(), latest_known_message[1] + 1):
-        [topic.publish(m) for m in ooo_buffer.extract(next_expected, latest_known_message[1] + 1)]
-
-def isComplete(l):
-    return sorted(l) == list(range(min(l), max(l)+1))
-
-class OutOfOrderBuffer: 
-    def __init__(self, name):
-        self.lock = threading.Lock()
-        self.length = 0
-        self.messages = []
-
-    def __len__(self): 
-        return self.length
-        
-    def publish(self, message, desired_index):
-        self.lock.acquire()
-        self.messages.append((message, desired_index))
-        self.length += 1
-        self.lock.release()
-    
-    def indices(self):
-        self.lock.acquire()
-        result = [x[1] for x in self.messages]
-        result.sort()
-        self.lock.release()
-        return result
-    
-    def has(self, start, end):
-        self.lock.acquire()
-        values = [start - 1] + [x[1] for x in self.messages] + [end]
-        self.lock.release()
-        return isComplete(values)
-    
-    def max(self):
-        self.lock.acquire()
-        x = ('', -1)
-        if len(self.messages) > 0:
-            x = max(self.messages, key=lambda x:x[1])
-        self.lock.release()
-        return x
-
-    def extract(self, start, end):
-        self.lock.acquire()
-        results = []
-        new_messages = []
-        for i, message in enumerate(self.messages):
-            if message[1] in range(start, end):
-                results.append(message)
-            else:
-                new_messages.append(message)
-        self.messages = new_messages
-        self.lock.release()
-        results.sort(key = lambda x: x[1])
-        return results
+    return 
         
 class Topic: 
     def __init__(self, name):
@@ -76,8 +21,10 @@ class Topic:
     def publish(self, message):
         self.lock.acquire()
         self.messages.append(message)
+        result = self.message_count
         self.message_count += 1
         self.lock.release()
+        return result 
     
     def consume(self, index):
         if index < 0: 


### PR DESCRIPTION
Adds fun commands to the REPL: 
```
jakesutton@Jakes-MacBook-Pro-3 pub-sub % python src/client_repl.py apache-zookeeper-3.7.0-bin/conf/zoo.cfg 
Zookeepers:     localhost:2181
 > consume cat
new message
 > primary cat
Node(localhost:3002,919179369)
 > brokers
Node(localhost:3005,46603166)
Node(localhost:3001,762500007)
Node(localhost:3002,919179369)
 > target localhost:3001
 (localhost:3001) > get_topics
cat
 (localhost:3001) > get_queue
usage (in target): get_queue <topic>
 (localhost:3001) > get_queue cat
['new message']
 (localhost:3001) > q
 > 
```