### PR TITLE
Fix multiple brokers RPC serialization bug

### DIFF
--- a/src/pubsubBroker.py
+++ b/src/pubsubBroker.py
@@ -80,11 +80,11 @@ class PubSubBroker:
 
         if repl1.key != self.my_address:
             r1Client = buildBrokerClient(repl1.key)
-            success_one = r1Client.broker.enqueue_replica(topic, message, message_index)
+            success_one = r1Client.broker.enqueue_replica(topic, message, message_index - 1)
 
         if repl2.key != self.my_address:
             r2Client = buildBrokerClient(repl2.key)
-            success_two = r2Client.broker.enqueue_replica(topic, message, message_index)
+            success_two = r2Client.broker.enqueue_replica(topic, message, message_index - 1)
 
         return True
 

--- a/src/topic.py
+++ b/src/topic.py
@@ -5,17 +5,17 @@ def consuming_enqueue(topic, client, message, index):
     if index < next_expected:
         return
     elif index > next_expected:
-        messages = client.broker.consume(topic, next_expected)
+        messages = client.broker.consume(topic.name, next_expected)
         for m in messages:
             topic.publish(m)
     else:
-        topic.publish(message)
-    return 
-        
+        topic.publish(message)    
+
 class Topic: 
     def __init__(self, name):
         self.lock = threading.Lock()
         self.messages = []
+        self.name = name
         
     def publish(self, message):
         self.lock.acquire()


### PR DESCRIPTION
Seems to resolve the RPC serialization failures from out of order messages? This is strange.

The reason that every messages appeared to have arrived out of order is that the return value of the topic was modified to reflect the next index in another change, but pubsubBroker was not modified to match the new value.